### PR TITLE
 Allow config to be changed without restart

### DIFF
--- a/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.cpp
+++ b/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.cpp
@@ -8,6 +8,7 @@
 #include "Engine/DataTable.h"
 #include "GameplayTagContainer.h"
 #include "WidgetBlueprint.h"
+#include "MDMetaDataEditorModule.h"
 
 UMDMetaDataEditorConfig::UMDMetaDataEditorConfig()
 {
@@ -254,6 +255,14 @@ void UMDMetaDataEditorConfig::ForEachFunctionMetaDataKey(const UBlueprint* Bluep
 		}
 
 		Func(Key);
+	}
+}
+
+void UMDMetaDataEditorConfig::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+	if (FMDMetaDataEditorModule* Module = FModuleManager::GetModulePtr<FMDMetaDataEditorModule>(TEXT("MDMetaDataEditor")))
+	{
+		Module->RestartModule();
 	}
 }
 

--- a/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.cpp
+++ b/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.cpp
@@ -258,6 +258,7 @@ void UMDMetaDataEditorConfig::ForEachFunctionMetaDataKey(const UBlueprint* Bluep
 	}
 }
 
+#if WITH_EDITOR
 void UMDMetaDataEditorConfig::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
 {
 	if (FMDMetaDataEditorModule* Module = FModuleManager::GetModulePtr<FMDMetaDataEditorModule>(TEXT("MDMetaDataEditor")))
@@ -265,6 +266,7 @@ void UMDMetaDataEditorConfig::PostEditChangeProperty(FPropertyChangedEvent& Prop
 		Module->RestartModule();
 	}
 }
+#endif //WITH_EDITOR
 
 TArray<FName> UMDMetaDataEditorConfig::GetMetaDataKeyNames() const
 {

--- a/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.h
+++ b/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.h
@@ -28,23 +28,27 @@ public:
 	void ForEachFunctionMetaDataKey(const UBlueprint* Blueprint, const TFunction<void(const FMDMetaDataKey&)>& Func) const;
 
 	// If true, the meta data keys will automatically be sorted alphabetically
-	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor", meta = (ConfigRestartRequired = "true"))
+	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor")
 	bool bSortMetaDataAlphabetically = true;
 
-	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor", meta = (ConfigRestartRequired = "true"))
+	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor")
 	bool bEnableMetaDataEditorForVariables = true;
 
-	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor", meta = (ConfigRestartRequired = "true"))
+	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor")
 	bool bEnableMetaDataEditorForLocalVariables = true;
 
-	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor", meta = (ConfigRestartRequired = "true"))
+	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor")
 	bool bEnableMetaDataEditorForFunctions = true;
 
-	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor", meta = (ConfigRestartRequired = "true"))
+	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor")
 	bool bEnableMetaDataEditorForCustomEvents = true;
 
-	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor", DisplayName = "Enable Meta Data Editor for Collapsed Graphs", meta = (ConfigRestartRequired = "true"))
+	UPROPERTY(EditDefaultsOnly, Config, Category = "Meta Data Editor", DisplayName = "Enable Meta Data Editor for Collapsed Graphs")
 	bool bEnableMetaDataEditorForTunnels = false;
+
+#if WITH_EDITOR
+	void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif //WITH_EDITOR
 
 private:
 	UFUNCTION()

--- a/Source/MDMetaDataEditor/Private/MDMetaDataEditorModule.cpp
+++ b/Source/MDMetaDataEditor/Private/MDMetaDataEditorModule.cpp
@@ -64,4 +64,10 @@ void FMDMetaDataEditorModule::ShutdownModule()
 	}
 }
 
+void FMDMetaDataEditorModule::RestartModule()
+{
+	ShutdownModule();
+	StartupModule();
+}
+
 IMPLEMENT_MODULE(FMDMetaDataEditorModule, MDMetaDataEditor)

--- a/Source/MDMetaDataEditor/Private/MDMetaDataEditorModule.cpp
+++ b/Source/MDMetaDataEditor/Private/MDMetaDataEditorModule.cpp
@@ -1,5 +1,7 @@
 ﻿// Copyright Dylan Dumesnil. All Rights Reserved.
 
+#include "MDMetaDataEditorModule.h"
+
 #include "BlueprintEditorModule.h"
 #include "Config/MDMetaDataEditorConfig.h"
 #include "Customizations/MDMetaDataEditorFunctionCustomization.h"
@@ -8,70 +10,58 @@
 #include "K2Node_CustomEvent.h"
 #include "K2Node_FunctionEntry.h"
 #include "K2Node_Tunnel.h"
-#include "Modules/ModuleManager.h"
 #include "PropertyEditorModule.h"
 
-class FMDMetaDataEditorModule : public IModuleInterface
+void FMDMetaDataEditorModule::StartupModule()
 {
-public:
-	virtual void StartupModule() override
+	const UMDMetaDataEditorConfig* Config = GetDefault<UMDMetaDataEditorConfig>();
+
+	FBlueprintEditorModule& BlueprintEditorModule = FModuleManager::LoadModuleChecked<FBlueprintEditorModule>("Kismet");
+
+	if (Config->bEnableMetaDataEditorForVariables)
 	{
-		const UMDMetaDataEditorConfig* Config = GetDefault<UMDMetaDataEditorConfig>();
-
-		FBlueprintEditorModule& BlueprintEditorModule = FModuleManager::LoadModuleChecked<FBlueprintEditorModule>("Kismet");
-
-		if (Config->bEnableMetaDataEditorForVariables)
-		{
-			VariableCustomizationHandle = BlueprintEditorModule.RegisterVariableCustomization(FProperty::StaticClass(), FOnGetVariableCustomizationInstance::CreateStatic(&FMDMetaDataEditorVariableCustomization::MakeInstance));
-		}
-
-		if (Config->bEnableMetaDataEditorForLocalVariables)
-		{
-			LocalVariableCustomizationHandle = BlueprintEditorModule.RegisterLocalVariableCustomization(FProperty::StaticClass(), FOnGetVariableCustomizationInstance::CreateStatic(&FMDMetaDataEditorVariableCustomization::MakeInstance));
-		}
-
-		if (Config->bEnableMetaDataEditorForFunctions)
-		{
-			FunctionCustomizationHandle = BlueprintEditorModule.RegisterFunctionCustomization(UK2Node_FunctionEntry::StaticClass(), FOnGetFunctionCustomizationInstance::CreateStatic(&FMDMetaDataEditorFunctionCustomization::MakeInstance));
-		}
-
-		if (Config->bEnableMetaDataEditorForTunnels)
-		{
-			TunnelCustomizationHandle = BlueprintEditorModule.RegisterFunctionCustomization(UK2Node_Tunnel::StaticClass(), FOnGetFunctionCustomizationInstance::CreateStatic(&FMDMetaDataEditorFunctionCustomization::MakeInstance));
-		}
-
-		if (Config->bEnableMetaDataEditorForCustomEvents)
-		{
-			EventCustomizationHandle = BlueprintEditorModule.RegisterFunctionCustomization(UK2Node_CustomEvent::StaticClass(), FOnGetFunctionCustomizationInstance::CreateStatic(&FMDMetaDataEditorFunctionCustomization::MakeInstance));
-		}
-
-		FPropertyEditorModule& PropertyEditorModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
-		PropertyEditorModule.RegisterCustomPropertyTypeLayout(FMDMetaDataEditorPropertyType::StaticStruct()->GetFName(), FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FMDMetaDataEditorPropertyTypeCustomization::MakeInstance));
+		VariableCustomizationHandle = BlueprintEditorModule.RegisterVariableCustomization(FProperty::StaticClass(), FOnGetVariableCustomizationInstance::CreateStatic(&FMDMetaDataEditorVariableCustomization::MakeInstance));
 	}
 
-	virtual void ShutdownModule() override
+	if (Config->bEnableMetaDataEditorForLocalVariables)
 	{
-		if (FBlueprintEditorModule* BlueprintEditorModule = FModuleManager::GetModulePtr<FBlueprintEditorModule>("Kismet"))
-		{
-			BlueprintEditorModule->UnregisterVariableCustomization(FProperty::StaticClass(), VariableCustomizationHandle);
-			BlueprintEditorModule->UnregisterLocalVariableCustomization(FProperty::StaticClass(), LocalVariableCustomizationHandle);
-			BlueprintEditorModule->UnregisterFunctionCustomization(UK2Node_FunctionEntry::StaticClass(), FunctionCustomizationHandle);
-			BlueprintEditorModule->UnregisterFunctionCustomization(UK2Node_Tunnel::StaticClass(), TunnelCustomizationHandle);
-			BlueprintEditorModule->UnregisterFunctionCustomization(UK2Node_CustomEvent::StaticClass(), EventCustomizationHandle);
-		}
-
-		if (FPropertyEditorModule* PropertyEditorModule = FModuleManager::GetModulePtr<FPropertyEditorModule>("PropertyEditor"))
-		{
-			PropertyEditorModule->UnregisterCustomPropertyTypeLayout(FMDMetaDataEditorPropertyType::StaticStruct()->GetFName());
-		}
+		LocalVariableCustomizationHandle = BlueprintEditorModule.RegisterLocalVariableCustomization(FProperty::StaticClass(), FOnGetVariableCustomizationInstance::CreateStatic(&FMDMetaDataEditorVariableCustomization::MakeInstance));
 	}
 
-private:
-	FDelegateHandle VariableCustomizationHandle;
-	FDelegateHandle LocalVariableCustomizationHandle;
-	FDelegateHandle FunctionCustomizationHandle;
-	FDelegateHandle TunnelCustomizationHandle;
-	FDelegateHandle EventCustomizationHandle;
-};
+	if (Config->bEnableMetaDataEditorForFunctions)
+	{
+		FunctionCustomizationHandle = BlueprintEditorModule.RegisterFunctionCustomization(UK2Node_FunctionEntry::StaticClass(), FOnGetFunctionCustomizationInstance::CreateStatic(&FMDMetaDataEditorFunctionCustomization::MakeInstance));
+	}
+
+	if (Config->bEnableMetaDataEditorForTunnels)
+	{
+		TunnelCustomizationHandle = BlueprintEditorModule.RegisterFunctionCustomization(UK2Node_Tunnel::StaticClass(), FOnGetFunctionCustomizationInstance::CreateStatic(&FMDMetaDataEditorFunctionCustomization::MakeInstance));
+	}
+
+	if (Config->bEnableMetaDataEditorForCustomEvents)
+	{
+		EventCustomizationHandle = BlueprintEditorModule.RegisterFunctionCustomization(UK2Node_CustomEvent::StaticClass(), FOnGetFunctionCustomizationInstance::CreateStatic(&FMDMetaDataEditorFunctionCustomization::MakeInstance));
+	}
+
+	FPropertyEditorModule& PropertyEditorModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
+	PropertyEditorModule.RegisterCustomPropertyTypeLayout(FMDMetaDataEditorPropertyType::StaticStruct()->GetFName(), FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FMDMetaDataEditorPropertyTypeCustomization::MakeInstance));
+}
+
+void FMDMetaDataEditorModule::ShutdownModule()
+{
+	if (FBlueprintEditorModule* BlueprintEditorModule = FModuleManager::GetModulePtr<FBlueprintEditorModule>("Kismet"))
+	{
+		BlueprintEditorModule->UnregisterVariableCustomization(FProperty::StaticClass(), VariableCustomizationHandle);
+		BlueprintEditorModule->UnregisterLocalVariableCustomization(FProperty::StaticClass(), LocalVariableCustomizationHandle);
+		BlueprintEditorModule->UnregisterFunctionCustomization(UK2Node_FunctionEntry::StaticClass(), FunctionCustomizationHandle);
+		BlueprintEditorModule->UnregisterFunctionCustomization(UK2Node_Tunnel::StaticClass(), TunnelCustomizationHandle);
+		BlueprintEditorModule->UnregisterFunctionCustomization(UK2Node_CustomEvent::StaticClass(), EventCustomizationHandle);
+	}
+
+	if (FPropertyEditorModule* PropertyEditorModule = FModuleManager::GetModulePtr<FPropertyEditorModule>("PropertyEditor"))
+	{
+		PropertyEditorModule->UnregisterCustomPropertyTypeLayout(FMDMetaDataEditorPropertyType::StaticStruct()->GetFName());
+	}
+}
 
 IMPLEMENT_MODULE(FMDMetaDataEditorModule, MDMetaDataEditor)

--- a/Source/MDMetaDataEditor/Private/MDMetaDataEditorModule.h
+++ b/Source/MDMetaDataEditor/Private/MDMetaDataEditorModule.h
@@ -1,0 +1,18 @@
+﻿// Copyright Dylan Dumesnil. All Rights Reserved.
+
+#pragma once
+
+class FMDMetaDataEditorModule : public IModuleInterface
+{
+public:
+	/** IModuleInterface implementation */
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+
+private:
+	FDelegateHandle VariableCustomizationHandle;
+	FDelegateHandle LocalVariableCustomizationHandle;
+	FDelegateHandle FunctionCustomizationHandle;
+	FDelegateHandle TunnelCustomizationHandle;
+	FDelegateHandle EventCustomizationHandle;
+};

--- a/Source/MDMetaDataEditor/Private/MDMetaDataEditorModule.h
+++ b/Source/MDMetaDataEditor/Private/MDMetaDataEditorModule.h
@@ -9,6 +9,8 @@ public:
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
 
+	void RestartModule();
+
 private:
 	FDelegateHandle VariableCustomizationHandle;
 	FDelegateHandle LocalVariableCustomizationHandle;


### PR DESCRIPTION
Added `RestartModule()` to `MDMetaDataEditorModule`.
Added `PostEditChangeProperty()` to `MDMetaDataEditorConfig`, which calls `RestartModule()`.
Removed ConfigRestartRequired metadata from config properties.

Example below of the Meta Data section being added and removed from the specified types when the setting changes. Re-selecting the node is required to rebuild the details panel.
![UnrealEditor_3E7PGN6Ak8](https://github.com/DoubleDeez/MDMetaDataEditor/assets/1462374/cd2fc558-fa33-49ad-9084-feb6f91cebcc)
