### PR TITLE
Move `Meta Data` section above `Input` section for Functions

### DIFF
--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorCustomizationBase.cpp
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorCustomizationBase.cpp
@@ -134,10 +134,20 @@ void FMDMetaDataEditorCustomizationBase::CustomizeDetails(IDetailLayoutBuilder& 
 		bIsFunction = true;
 	}
 
-	// Put Meta Data above Default Value for Variables
-	const int32 MetaDataSortOrder = DetailLayout.EditCategory("Variable").GetSortOrder() + 1;
-	DetailLayout.EditCategory("MetaData").SetSortOrder(MetaDataSortOrder);
-	DetailLayout.EditCategory("DefaultValue").SetSortOrder(MetaDataSortOrder + 1);
+	if (bIsProperty)
+	{
+		// Put Meta Data above Default Value for Variables
+		const int32 MetaDataSortOrder = DetailLayout.EditCategory("Variable").GetSortOrder() + 1;
+		DetailLayout.EditCategory("MetaData").SetSortOrder(MetaDataSortOrder);
+		DetailLayout.EditCategory("DefaultValue").SetSortOrder(MetaDataSortOrder + 1);
+	}
+	else if (bIsFunction)
+	{
+		// Put Meta Data above Inputs for Functions
+		const int32 MetaDataSortOrder = DetailLayout.EditCategory("Graph").GetSortOrder() + 1;
+		DetailLayout.EditCategory("MetaData").SetSortOrder(MetaDataSortOrder);
+		DetailLayout.EditCategory("Inputs").SetSortOrder(MetaDataSortOrder + 1);
+	}
 
 	TMap<FName, IDetailGroup*> GroupMap;
 


### PR DESCRIPTION
This is nice, because `Meta Data` is like an extended `Graph` section. I know my muscle memory is such that Inputs are at the bottom of a function.

![image](https://github.com/DoubleDeez/MDMetaDataEditor/assets/1462374/ed69d33c-791a-4f00-8424-76f527f17666)
