### PR TITLE
Meta Data Keys display with spaces & optional `Display Name Override`

### DIFF
--- a/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.cpp
+++ b/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.cpp
@@ -11,6 +11,8 @@
 #include "Modules/ModuleManager.h"
 #include "WidgetBlueprint.h"
 
+#define LOCTEXT_NAMESPACE "MDMetaDataEditor"
+
 UMDMetaDataEditorConfig::UMDMetaDataEditorConfig()
 {
 	// Setup some useful defaults, with some ugly code
@@ -111,7 +113,7 @@ UMDMetaDataEditorConfig::UMDMetaDataEditorConfig()
 		{ UEdGraphSchema_K2::PC_Struct, NAME_None, FGameplayTagContainer::StaticStruct() }
 	};
 	MetaDataKeys.Append({
-		FMDMetaDataKey{ TEXT("Categories"), EMDMetaDataEditorKeyType::GameplayTagContainer, TEXT("Limit which gameplay tags may be selected to one or more specific root tags.") }.SetSupportedProperties(GameplayTagTypes)
+		FMDMetaDataKey{ TEXT("Categories"), EMDMetaDataEditorKeyType::GameplayTagContainer, TEXT("Limit which gameplay tags may be selected to one or more specific root tags.") }.SetSupportedProperties(GameplayTagTypes).SetDisplayNameOverride(LOCTEXT("Categories_DisplayName","Tag Filter"))
 	});
 
 	// Primary Asset IDs
@@ -281,3 +283,5 @@ TArray<FName> UMDMetaDataEditorConfig::GetMetaDataKeyNames() const
 
 	return Result;
 }
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorCustomizationBase.cpp
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorCustomizationBase.cpp
@@ -189,8 +189,8 @@ void FMDMetaDataEditorCustomizationBase::CustomizeDetails(IDetailLayoutBuilder& 
 		}
 
 		FDetailWidgetRow& MetaDataRow = (Group != nullptr)
-			? Group->AddWidgetRow().FilterString(FText::FromName(Key.Key))
-			: Category.AddCustomRow(FText::FromName(Key.Key));
+			? Group->AddWidgetRow().FilterString(Key.GetFilterText())
+			: Category.AddCustomRow(Key.GetFilterText());
 
 		const FUIAction CopyAction = {
 			FExecuteAction::CreateSP(this, &FMDMetaDataEditorCustomizationBase::CopyMetaData, Key.Key),
@@ -211,7 +211,7 @@ void FMDMetaDataEditorCustomizationBase::CustomizeDetails(IDetailLayoutBuilder& 
 				SNew(STextBlock)
 				.Font(DetailLayout.GetDetailFont())
 				.Text(Key.GetKeyDisplayText())
-				.ToolTipText(FText::FromString(Key.Description))
+				.ToolTipText(Key.GetToolTipText())
 			]
 			.ValueContent()
 			[

--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorCustomizationBase.cpp
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorCustomizationBase.cpp
@@ -210,7 +210,7 @@ void FMDMetaDataEditorCustomizationBase::CustomizeDetails(IDetailLayoutBuilder& 
 			[
 				SNew(STextBlock)
 				.Font(DetailLayout.GetDetailFont())
-				.Text(FText::FromName(Key.Key))
+				.Text(Key.GetKeyDisplayText())
 				.ToolTipText(FText::FromString(Key.Description))
 			]
 			.ValueContent()

--- a/Source/MDMetaDataEditor/Private/Types/MDMetaDataKey.cpp
+++ b/Source/MDMetaDataEditor/Private/Types/MDMetaDataKey.cpp
@@ -38,6 +38,11 @@ bool FMDMetaDataKey::DoesSupportProperty(const FProperty* Property) const
 	return false;
 }
 
+FText FMDMetaDataKey::GetKeyDisplayText() const
+{
+	return FText::FromString(FName::NameToDisplayString(Key.ToString(), false));
+}
+
 bool FMDMetaDataKey::operator==(const FMDMetaDataKey& Other) const
 {
 	return Key == Other.Key && KeyType == Other.KeyType;

--- a/Source/MDMetaDataEditor/Private/Types/MDMetaDataKey.cpp
+++ b/Source/MDMetaDataEditor/Private/Types/MDMetaDataKey.cpp
@@ -40,7 +40,34 @@ bool FMDMetaDataKey::DoesSupportProperty(const FProperty* Property) const
 
 FText FMDMetaDataKey::GetKeyDisplayText() const
 {
-	return FText::FromString(FName::NameToDisplayString(Key.ToString(), false));
+	if (bUseDisplayNameOverride)
+	{
+		return DisplayNameOverride;
+	}
+	else
+	{
+		return FText::FromString(FName::NameToDisplayString(Key.ToString(), false));
+	}
+}
+
+FText FMDMetaDataKey::GetToolTipText() const
+{
+	FString ToolTip = Description;
+	if (bUseDisplayNameOverride)
+	{
+		ToolTip += "\r\n\r\nMeta Data Key: \"" + Key.ToString() + "\"";
+	}
+	return FText::FromString(ToolTip);
+}
+
+FText FMDMetaDataKey::GetFilterText() const
+{
+	FString Filter = Key.ToString();
+	if (bUseDisplayNameOverride)
+	{
+		Filter += TEXT(" ") + DisplayNameOverride.ToString();
+	}
+	return FText::FromString(Filter);
 }
 
 bool FMDMetaDataKey::operator==(const FMDMetaDataKey& Other) const

--- a/Source/MDMetaDataEditor/Private/Types/MDMetaDataKey.h
+++ b/Source/MDMetaDataEditor/Private/Types/MDMetaDataKey.h
@@ -156,7 +156,7 @@ public:
 	bool DoesSupportProperty(const FProperty* Property) const;
 
 	// Overrides the User friendly name to show for this key if not empty.
-	UPROPERTY(EditAnywhere, Config, Category = "Meta Data Editor", meta = (ToggleInlineEditCondition))
+	UPROPERTY(EditAnywhere, Config, Category = "Meta Data Editor", meta = (InlineEditConditionToggle))
 	bool bUseDisplayNameOverride = false;
 
 	// Overrides the User friendly name to show for this key if not empty.

--- a/Source/MDMetaDataEditor/Private/Types/MDMetaDataKey.h
+++ b/Source/MDMetaDataEditor/Private/Types/MDMetaDataKey.h
@@ -155,7 +155,18 @@ public:
 	bool DoesSupportBlueprint(const UBlueprint* Blueprint) const;
 	bool DoesSupportProperty(const FProperty* Property) const;
 
+	// Overrides the User friendly name to show for this key if not empty.
+	UPROPERTY(EditAnywhere, Config, Category = "Meta Data Editor", meta = (ToggleInlineEditCondition))
+	bool bUseDisplayNameOverride = false;
+
+	// Overrides the User friendly name to show for this key if not empty.
+	UPROPERTY(EditAnywhere, Config, Category = "Meta Data Editor", meta = (DisplayAfter = "KeyType", EditCondition = "bUseDisplayNameOverride"))
+	FText DisplayNameOverride;
+	FMDMetaDataKey& SetDisplayNameOverride(FText InDisplayNameOverride) { bUseDisplayNameOverride = true; DisplayNameOverride = InDisplayNameOverride; return *this; }
+
 	FText GetKeyDisplayText() const;
+	FText GetToolTipText() const;
+	FText GetFilterText() const;
 
 	bool operator==(const FMDMetaDataKey& Other) const;
 	bool operator!=(const FMDMetaDataKey& Other) const

--- a/Source/MDMetaDataEditor/Private/Types/MDMetaDataKey.h
+++ b/Source/MDMetaDataEditor/Private/Types/MDMetaDataKey.h
@@ -155,6 +155,8 @@ public:
 	bool DoesSupportBlueprint(const UBlueprint* Blueprint) const;
 	bool DoesSupportProperty(const FProperty* Property) const;
 
+	FText GetKeyDisplayText() const;
+
 	bool operator==(const FMDMetaDataKey& Other) const;
 	bool operator!=(const FMDMetaDataKey& Other) const
 	{


### PR DESCRIPTION
- Meta Data Keys now display with spaces between words.
- Meta Data Keys now have optional `Display Name Override`
  - Filtering works for key & name override.
  - When `Display Name Override` is used, the tooltip will note the original key.
- `Display Name Override` is used on `Categories` for `Gameplay Tag` because it is an unintuitive name.

<html><body>
<!--StartFragment-->

Config | Details Panel
-- | --
![Key Config](https://github.com/DoubleDeez/MDMetaDataEditor/assets/1462374/fe3779f3-b8ed-48fa-adcf-a75d074981e3) | ![UnrealEditor_Hsy0YUoYow](https://github.com/DoubleDeez/MDMetaDataEditor/assets/1462374/de80b882-45d8-4790-b46d-f05676bc1206)

<!--EndFragment-->
</body>
</html>