### PR TITLE
Fix Crash in `DoesMatchProperty`

### DIFF
--- a/Source/MDMetaDataEditor/Private/Types/MDMetaDataEditorPropertyType.cpp
+++ b/Source/MDMetaDataEditor/Private/Types/MDMetaDataEditorPropertyType.cpp
@@ -182,7 +182,12 @@ bool FMDMetaDataEditorPropertyType::DoesMatchProperty(const FProperty* Property)
 
 	if (PropertyType == UEdGraphSchema_K2::PC_Class || PropertyType == UEdGraphSchema_K2::PC_SoftClass)
 	{
-		if (!EffectiveProp->IsA<FClassProperty>() && !EffectiveProp->IsA<FSoftClassProperty>())
+		if (PropertyType == UEdGraphSchema_K2::PC_Class && !EffectiveProp->IsA<FClassProperty>())
+		{
+			return false;
+		}
+
+		if (PropertyType == UEdGraphSchema_K2::PC_SoftClass && !EffectiveProp->IsA<FSoftClassProperty>())
 		{
 			return false;
 		}


### PR DESCRIPTION
### Reproduce Crash:
- Open a blueprint. *I was opening the level blueprint.*
- Make new variable.
- Set variable type to a class. *I was doing Actor->Class.*
- Crash. https://github.com/DoubleDeez/MDMetaDataEditor/blob/dada2b6cd26ca19439b0aeee2f7503fade9e69c3/Source/MDMetaDataEditor/Private/Types/MDMetaDataEditorPropertyType.cpp#L190

### Reason:
If the `PropertyType` being checked is a `SoftClass`, but the `Property` is a `Class`, then it was crashing when trying to get the `MetaClass`.

### Fix 
Now returns false if Softness doesn't match.