### PR TITLE
Fix Float/Double meta data options not showing up.

### DIFF
--- a/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.cpp
+++ b/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.cpp
@@ -35,9 +35,8 @@ UMDMetaDataEditorConfig::UMDMetaDataEditorConfig()
 	const TSet<FMDMetaDataEditorPropertyType> NumericTypes = {
 		{ UEdGraphSchema_K2::PC_Int },
 		{ UEdGraphSchema_K2::PC_Int64 },
-		{ UEdGraphSchema_K2::PC_Float },
-		{ UEdGraphSchema_K2::PC_Double },
-		{ UEdGraphSchema_K2::PC_Real },
+		{ UEdGraphSchema_K2::PC_Real, UEdGraphSchema_K2::PC_Float },
+		{ UEdGraphSchema_K2::PC_Real, UEdGraphSchema_K2::PC_Double },
 	};
 	MetaDataKeys.Append({
 			FMDMetaDataKey{ TEXT("NoSpinbox"), EMDMetaDataEditorKeyType::Boolean, TEXT("Disables the click and drag functionality for setting the value of this property.") }.SetSupportedProperties(NumericTypes)
@@ -57,9 +56,8 @@ UMDMetaDataEditorConfig::UMDMetaDataEditorConfig()
 
 	// Float types
 	const TSet<FMDMetaDataEditorPropertyType> FloatTypes = {
-		{ UEdGraphSchema_K2::PC_Float },
-		{ UEdGraphSchema_K2::PC_Double },
-		{ UEdGraphSchema_K2::PC_Real },
+		{ UEdGraphSchema_K2::PC_Real, UEdGraphSchema_K2::PC_Float },
+		{ UEdGraphSchema_K2::PC_Real, UEdGraphSchema_K2::PC_Double },
 	};
 	MetaDataKeys.Append({
 		FMDMetaDataKey{ TEXT("SliderExponent"), EMDMetaDataEditorKeyType::Float, TEXT("How fast the value should change while dragging to set the value.") }.SetSupportedProperties(FloatTypes).SetMinFloat(1.f),
@@ -223,6 +221,15 @@ void UMDMetaDataEditorConfig::PostInitProperties()
 		{
 			return A.Key.Compare(B.Key) < 0;
 		});
+	}
+
+	// Fix Supported Property Types which may be coming from old configs.
+	for (FMDMetaDataKey& Key : MetaDataKeys)
+	{
+		for (FMDMetaDataEditorPropertyType& SupportedPropertyType : Key.SupportedPropertyTypes)
+		{
+			SupportedPropertyType.FixUp();
+		}
 	}
 }
 

--- a/Source/MDMetaDataEditor/Private/Types/MDMetaDataEditorPropertyType.cpp
+++ b/Source/MDMetaDataEditor/Private/Types/MDMetaDataEditorPropertyType.cpp
@@ -243,6 +243,23 @@ bool FMDMetaDataEditorPropertyType::DoesMatchProperty(const FProperty* Property)
 		&& PropertySubTypeMemberReference == PinType.PinSubCategoryMemberReference;
 }
 
+void FMDMetaDataEditorPropertyType::FixUp()
+{
+	// Float/Double types must be set to Real. The sub type is Float/Double.
+	// If Float/Double is the primary type, then move it to subtype, and set the primary type to Real.
+	if((PropertyType == UEdGraphSchema_K2::PC_Float || PropertyType == UEdGraphSchema_K2::PC_Double) && PropertySubType == NAME_None)
+	{
+		PropertySubType = PropertyType;
+		PropertyType = UEdGraphSchema_K2::PC_Real;
+	}
+
+	// Real type needs a subtype, default to Double.
+	if (PropertyType == UEdGraphSchema_K2::PC_Real && PropertySubType == NAME_None)
+	{
+		PropertySubType = UEdGraphSchema_K2::PC_Double;
+	}
+}
+
 bool FMDMetaDataEditorPropertyType::operator==(const FMDMetaDataEditorPropertyType& Other) const
 {
 	return PropertyType == Other.PropertyType

--- a/Source/MDMetaDataEditor/Private/Types/MDMetaDataEditorPropertyType.h
+++ b/Source/MDMetaDataEditor/Private/Types/MDMetaDataEditorPropertyType.h
@@ -26,6 +26,25 @@ struct FMDMetaDataEditorPropertyType
 
 public:
 
+	FMDMetaDataEditorPropertyType(
+		FName PropertyType = NAME_None,
+		FName PropertySubType = NAME_None, 
+		TSoftObjectPtr<UObject> PropertySubTypeObject = nullptr,
+		FSimpleMemberReference PropertySubTypeMemberReference = FSimpleMemberReference(),
+		FInstancedStruct ValueType = FInstancedStruct(),
+		EMDMetaDataPropertyContainerType ContainerType = EMDMetaDataPropertyContainerType::None
+		)
+		: PropertyType(PropertyType)
+		, PropertySubType(PropertySubType)
+		, PropertySubTypeObject(PropertySubTypeObject)
+		, PropertySubTypeMemberReference(PropertySubTypeMemberReference)
+		, ValueType(ValueType)
+		, ContainerType(ContainerType)
+	{
+		// Fix any newly constructed property types.
+		FixUp();
+	}
+
 	FEdGraphPinType ToGraphPinType() const;
 	FEdGraphTerminalType ToGraphTerminalType() const;
 
@@ -33,6 +52,8 @@ public:
 	void SetFromGraphTerminalType(const FEdGraphTerminalType& GraphTerminalType);
 
 	bool DoesMatchProperty(const FProperty* Property) const;
+
+	void FixUp();
 
 	UPROPERTY(EditAnywhere, Config, Category = "Meta Data Editor")
 	FName PropertyType = NAME_None;


### PR DESCRIPTION
### Unreal Engine Version: `5.3`
 *I didn't test in other engine versions.*

### Bug
Metadata keys which explicitly supported Float/Double/Real types do not show up. (i.e. `SliderExponent`, `Delta`, `Multiple`, `NoSpinbox`)

### Cause
In `UE 5.3` Floats and Doubles are actually Reals, with the subtype of Float/Double. These keys were failing to be supported because `Key.DoesSupportProperty(Property)` would return false. Because it requires the type and subtype to match.

### Fix
- The config was updated to initialize
  - floats as  `{ UEdGraphSchema_K2::PC_Real, UEdGraphSchema_K2::PC_Float }`
  - doubles  `{ UEdGraphSchema_K2::PC_Real, UEdGraphSchema_K2::PC_Double }`
  - With no extra `{ UEdGraphSchema_K2::PC_Real }`
- The constructor for the struct was updated to `FixUp()` the values if they are being initialized incorrectly by code.
- The config was updated to also call `FixUp()` on `PostInitProperties()` so that configurations which were saved with previous versions would be fixed also.

### Tested
- Picking double type in the plugin settings menu already correctly set the type & subtype.
- I verified: The new initializing of floats/doubles in the config fixes the issue.
- I verified: Loading an old broken config gets fixed.
- I verified: Adding the type's in code the old way gets automatically fixed.
  - Adding a naked float/double gets fixed.
  - Adding a naked real gets set to be a double.
  - Duplicates are automatically removed (because it is a `TSet`).