### PR TITLE
Push metadata changes to skeleton class as well as generated class

### DIFF
--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorFieldView.cpp
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorFieldView.cpp
@@ -83,8 +83,9 @@ namespace MDMDEFV_Private
 
 const FString FMDMetaDataEditorFieldView::MultipleValues = TEXT("Multiple Values");
 
-FMDMetaDataEditorFieldView::FMDMetaDataEditorFieldView(FProperty* InProperty, UBlueprint* InBlueprint)
+FMDMetaDataEditorFieldView::FMDMetaDataEditorFieldView(FProperty* InProperty, FProperty* InSkelProperty, UBlueprint* InBlueprint)
 	: MetadataProperty(InProperty)
+	, MetadataSkeletonProperty(InSkelProperty)
 	, BlueprintPtr(InBlueprint)
 {
 	if (InProperty != nullptr)
@@ -124,8 +125,9 @@ FMDMetaDataEditorFieldView::FMDMetaDataEditorFieldView(FProperty* InProperty, UU
 {
 }
 
-FMDMetaDataEditorFieldView::FMDMetaDataEditorFieldView(FProperty* InProperty, UK2Node_EditablePinBase* InNode)
+FMDMetaDataEditorFieldView::FMDMetaDataEditorFieldView(FProperty* InProperty, FProperty* InSkelProperty, UK2Node_EditablePinBase* InNode)
 	: MetadataProperty(InProperty)
+	, MetadataSkeletonProperty(InSkelProperty)
 	, BlueprintPtr(IsValid(InNode) ? InNode->GetBlueprint() : nullptr)
 {
 	if (InProperty != nullptr)
@@ -863,6 +865,11 @@ void FMDMetaDataEditorFieldView::SetMetadataValue(const FName& Key, const FStrin
 					Property->SetMetaData(Key, FString(Value));
 					VariableDescription.SetMetaData(Key, Value);
 					bDidFindMetaData = true;
+
+					if (FProperty* SkeletonProperty = MetadataSkeletonProperty.Get())
+					{
+						SkeletonProperty->SetMetaData(Key, FString(Value));
+					}
 				}
 			}
 
@@ -878,6 +885,11 @@ void FMDMetaDataEditorFieldView::SetMetadataValue(const FName& Key, const FStrin
 							FuncNode->Modify();
 							Property->SetMetaData(Key, FString(Value));
 							VariableDescription.SetMetaData(Key, Value);
+
+							if (FProperty* SkeletonProperty = MetadataSkeletonProperty.Get())
+							{
+								SkeletonProperty->SetMetaData(Key, FString(Value));
+							}
 						}
 					}
 				}
@@ -892,6 +904,11 @@ void FMDMetaDataEditorFieldView::SetMetadataValue(const FName& Key, const FStrin
 			}
 
 			Property->SetMetaData(Key, FString(Value));
+
+			if (FProperty* SkeletonProperty = MetadataSkeletonProperty.Get())
+			{
+				SkeletonProperty->SetMetaData(Key, FString(Value));
+			}
 		}
 	}
 

--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorFieldView.h
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorFieldView.h
@@ -45,9 +45,9 @@ enum class EMDMetaDataEditorFieldType : uint8
 class MDMETADATAEDITOR_API FMDMetaDataEditorFieldView : public TSharedFromThis<FMDMetaDataEditorFieldView>
 {
 public:
-	FMDMetaDataEditorFieldView(FProperty* InProperty, UBlueprint* InBlueprint);
+	FMDMetaDataEditorFieldView(FProperty* InProperty, FProperty* InSkelProperty, UBlueprint* InBlueprint);
 	FMDMetaDataEditorFieldView(FProperty* InProperty, UUserDefinedStruct* InUserDefinedStruct);
-	FMDMetaDataEditorFieldView(FProperty* InProperty, UK2Node_EditablePinBase* InNode);
+	FMDMetaDataEditorFieldView(FProperty* InProperty, FProperty* InSkelProperty, UK2Node_EditablePinBase* InNode);
 	explicit FMDMetaDataEditorFieldView(UUserDefinedStruct* InUserDefinedStruct);
 	FMDMetaDataEditorFieldView(UK2Node_FunctionEntry* InFunctionEntry, UBlueprint* InBlueprint);
 	FMDMetaDataEditorFieldView(UK2Node_Tunnel* InTunnel, UBlueprint* InBlueprint);
@@ -109,6 +109,7 @@ private:
 	bool CanPasteMetadata(FName Key) const;
 
 	TWeakFieldPtr<FProperty> MetadataProperty;
+	TWeakFieldPtr<FProperty> MetadataSkeletonProperty;
 	TWeakObjectPtr<UUserDefinedStruct> MetadataStruct;
 	TWeakObjectPtr<UK2Node_FunctionEntry> MetadataFunctionEntry;
 	TWeakObjectPtr<UK2Node_Tunnel> MetadataTunnel;

--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorFunctionCustomization.cpp
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorFunctionCustomization.cpp
@@ -65,12 +65,12 @@ namespace MDMDEFC_Private
 		return nullptr;
 	}
 
-	FProperty* FindNodeProperty(const UK2Node_EditablePinBase* Node, const TSharedPtr<FUserPinInfo>& PinInfo)
+	FProperty* FindNodeProperty(const UK2Node_EditablePinBase* Node, const TSharedPtr<FUserPinInfo>& PinInfo, bool bUseSkelClass)
 	{
 		// Specifically grab the generated class, not the skeleton class so that UMDMetaDataEditorBlueprintCompilerExtension can grab the meta data after the BP is compiled
 
 		const UBlueprint* Blueprint = IsValid(Node) ? Node->GetBlueprint() : nullptr;
-		const UClass* Class = IsValid(Blueprint) ? Blueprint->GeneratedClass : nullptr;
+		const UClass* Class = IsValid(Blueprint) ? (bUseSkelClass ? Blueprint->SkeletonGeneratedClass : Blueprint->GeneratedClass) : nullptr;
 		const UFunction* Function = nullptr;
 
 		if (const UK2Node_FunctionResult* ResultNode = Cast<UK2Node_FunctionResult>(Node))
@@ -178,13 +178,14 @@ void FMDMetaDataEditorFunctionCustomization::InitFieldViews(UObject* Obj)
 	{
 		for (const TSharedPtr<FUserPinInfo>& PinInfo : Node->UserDefinedPins)
 		{
-			FProperty* ParamProperty = MDMDEFC_Private::FindNodeProperty(Node, PinInfo);
+			FProperty* ParamProperty = MDMDEFC_Private::FindNodeProperty(Node, PinInfo, false);
 			if (ParamProperty == nullptr)
 			{
 				continue;
 			}
+			FProperty* SkeletonProperty = MDMDEFC_Private::FindNodeProperty(Node, PinInfo, true);
 
-			TSharedPtr<FMDMetaDataEditorFieldView> ParamFieldView = MakeShared<FMDMetaDataEditorFieldView>(ParamProperty, Node);
+			TSharedPtr<FMDMetaDataEditorFieldView> ParamFieldView = MakeShared<FMDMetaDataEditorFieldView>(ParamProperty, SkeletonProperty, Node);
 			ParamFieldView->RequestRefresh.BindSP(this, &FMDMetaDataEditorFunctionCustomization::RefreshDetails);
 			ParamFieldViews.Emplace(MoveTemp(ParamFieldView));
 		}

--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorVariableCustomization.cpp
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorVariableCustomization.cpp
@@ -34,8 +34,10 @@ void FMDMetaDataEditorVariableCustomization::CustomizeObject(IDetailLayoutBuilde
 			|| (!bIsLocalVariable && Config->bEnableMetaDataEditorForVariables);
 		if (bIsEnabled)
 		{
+			FProperty* SkeletonProperty = GetBlueprint()->SkeletonGeneratedClass->FindPropertyByName(Property->GetFName());
+
 			TMap<FName, IDetailGroup*> GroupMap;
-			VariableFieldView = MakeShared<FMDMetaDataEditorFieldView>(Property, GetBlueprint());
+			VariableFieldView = MakeShared<FMDMetaDataEditorFieldView>(Property, SkeletonProperty, GetBlueprint());
 			VariableFieldView->RequestRefresh.BindSP(this, &FMDMetaDataEditorVariableCustomization::RefreshDetails);
 			VariableFieldView->GenerateMetadataEditor(DetailLayout, GroupMap);
 		}


### PR DESCRIPTION
While working on custom blueprint nodes that leveraged the metadata information, I found that only the generated class was being modified. It is also very useful to immediately update the skeleton class with the same information so that it can be immediately reflected my blueprint nodes without having to recompile (assuming the property already has the metadata field available after a first compile).