### PR TITLE
Remove StructUtils dependency from UE 5.5 & onward

### DIFF
--- a/MDMetaDataEditor.uplugin
+++ b/MDMetaDataEditor.uplugin
@@ -29,10 +29,6 @@
 		{
 			"Name": "GameplayTagsEditor",
 			"Enabled": true
-		},
-		{
-			"Name": "StructUtils",
-			"Enabled": true
 		}
 	]
 }

--- a/Source/MDMetaDataEditor/MDMetaDataEditor.Build.cs
+++ b/Source/MDMetaDataEditor/MDMetaDataEditor.Build.cs
@@ -24,11 +24,16 @@ public class MDMetaDataEditor : ModuleRules
 				"KismetWidgets",
 				"Slate",
 				"SlateCore",
-				"StructUtils",
 				"UMG",
 				"UMGEditor",
 				"UnrealEd"
 			}
 		);
-	}
+
+        // Use StructUtils 5.0 - 5.4
+        if (Target.Version.MajorVersion >= 5 && Target.Version.MinorVersion <= 4)
+        {
+            PrivateDependencyModuleNames.Add("StructUtils");
+        }
+    }
 }


### PR DESCRIPTION
StructUtils is not needed from UE 5.5 onward. The compiler makes a note of this every time the plugin is compiled. 
Fixes #18.