### PR TITLE
Update compatibility to UE 5.6

### DIFF
--- a/MDMetaDataEditor.uplugin
+++ b/MDMetaDataEditor.uplugin
@@ -29,10 +29,6 @@
 		{
 			"Name": "GameplayTagsEditor",
 			"Enabled": true
-		},
-		{
-			"Name": "StructUtils",
-			"Enabled": true
 		}
 	]
 }

--- a/Source/MDMetaDataEditor/MDMetaDataEditor.Build.cs
+++ b/Source/MDMetaDataEditor/MDMetaDataEditor.Build.cs
@@ -24,11 +24,16 @@ public class MDMetaDataEditor : ModuleRules
 				"KismetWidgets",
 				"Slate",
 				"SlateCore",
-				"StructUtils",
 				"UMG",
 				"UMGEditor",
 				"UnrealEd"
 			}
 		);
-	}
+
+        // Use StructUtils 5.0 - 5.4
+        if (Target.Version.MajorVersion >= 5 && Target.Version.MinorVersion <= 4)
+        {
+            PrivateDependencyModuleNames.Add("StructUtils");
+        }
+    }
 }

--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorFieldView.cpp
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorFieldView.cpp
@@ -29,7 +29,7 @@
 #include "Widgets/SMDMetaDataStringComboBox.h"
 #include "Widgets/Text/STextBlock.h"
 
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 5
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5) // On or after UE 5.5
 #include "StructUtils/UserDefinedStruct.h"
 #endif
 
@@ -213,7 +213,11 @@ const TMap<FName, FString>* FMDMetaDataEditorFieldView::GetMetadataMap() const
 	}
 	else if (UUserDefinedStruct* Struct = MetadataStruct.Get())
 	{
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6) // On or after UE 5.6
+		return FMetaData::GetMapForObject(Struct);
+#else // Pre UE 5.6
 		return UMetaData::GetMapForObject(Struct);
+#endif
 	}
 
 	return nullptr;

--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorStructChangeHandler.cpp
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorStructChangeHandler.cpp
@@ -13,7 +13,11 @@ void FMDMetaDataEditorStructChangeHandler::PreChange(const UUserDefinedStruct* S
 		FMDMetaDataEditorCachedStructMetadata& Cache = CachedStructMetadata.FindOrAdd(Struct);
 		if (Cache.Count++ == 0)
 		{
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6) // On or after UE 5.6
+			if (TMap<FName, FString>* MetaDataMap = FMetaData::GetMapForObject(Struct))
+#else // Pre UE 5.6
 			if (TMap<FName, FString>* MetaDataMap = UMetaData::GetMapForObject(Struct))
+#endif
 			{
 				Cache.StructMetadata = *MetaDataMap;
 			}
@@ -37,7 +41,11 @@ void FMDMetaDataEditorStructChangeHandler::PostChange(const UUserDefinedStruct* 
 		{
 			if (--Cache->Count == 0)
 			{
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6) // On or after UE 5.6
+				TMap<FName, FString>& MetaDataMap = Struct->GetOutermost()->GetMetaData().ObjectMetaDataMap.FindOrAdd(Struct);
+#else // Pre UE 5.6
 				TMap<FName, FString>& MetaDataMap = Struct->GetOutermost()->GetMetaData()->ObjectMetaDataMap.FindOrAdd(Struct);
+#endif
 				MetaDataMap.Append(MoveTemp(Cache->StructMetadata));
 
 				for (TFieldIterator<FProperty> PropertyIter(Struct); PropertyIter; ++PropertyIter)

--- a/Source/MDMetaDataEditor/Private/Widgets/SMDMetaDataGameplayTagPicker.cpp
+++ b/Source/MDMetaDataEditor/Private/Widgets/SMDMetaDataGameplayTagPicker.cpp
@@ -5,10 +5,10 @@
 
 #include "DetailLayoutBuilder.h"
 #include "Runtime/Launch/Resources/Version.h"
-#if ENGINE_MAJOR_VERSION > 5 || ENGINE_MINOR_VERSION >= 3
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3) // On or after UE 5.3
 #include "SGameplayTagCombo.h"
 #include "SGameplayTagPicker.h"
-#else
+#else // Pre UE 5.3
 #include "SGameplayTagWidget.h"
 #endif
 #include "Widgets/Input/SComboButton.h"
@@ -39,7 +39,7 @@ void SMDMetaDataGameplayTagPicker::Construct(const FArguments& InArgs)
 
 	ChildSlot
 	[
-#if ENGINE_MAJOR_VERSION > 5 || ENGINE_MINOR_VERSION >= 3
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3) // On or after UE 5.3
 		!bIsMulti
 			? TSharedRef<SWidget>(SNew(SGameplayTagCombo)
 				.Tag(GameplayTagContainer.First())
@@ -57,12 +57,12 @@ void SMDMetaDataGameplayTagPicker::Construct(const FArguments& InArgs)
 		]
 		.MenuContent()
 		[
-#if ENGINE_MAJOR_VERSION > 5 || ENGINE_MINOR_VERSION >= 3
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3) // On or after UE 5.3
 			SNew(SGameplayTagPicker)
 				.ShowMenuItems(true)
 				.TagContainers({ GameplayTagContainer })
 				.OnTagChanged(this, &SMDMetaDataGameplayTagPicker::UpdateMetaDataContainer)
-#else
+#else // Pre UE 5.3
 			SNew(SGameplayTagWidget, TArray<SGameplayTagWidget::FEditableGameplayTagContainerDatum>{ { nullptr, &GameplayTagContainer } })
 			.MultiSelect(bIsMulti)
 			.OnTagChanged(this, &SMDMetaDataGameplayTagPicker::UpdateMetaData, bIsMulti)


### PR DESCRIPTION
`UMetaData` was deprecated, now use `FMetaData`.
Maintains backwards compatibility.