### PR TITLE
5.8 updates

### DIFF
--- a/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.cpp
+++ b/Source/MDMetaDataEditor/Private/Config/MDMetaDataEditorConfig.cpp
@@ -6,11 +6,17 @@
 #include "Animation/WidgetAnimation.h"
 #include "Components/Widget.h"
 #include "Engine/DataTable.h"
-#include "Engine/UserDefinedStruct.h"
 #include "GameplayTagContainer.h"
 #include "MDMetaDataEditorModule.h"
+#include "Misc/EngineVersionComparison.h"
 #include "Modules/ModuleManager.h"
 #include "WidgetBlueprint.h"
+
+#if UE_VERSION_NEWER_THAN_OR_EQUAL(5,5,0)
+	#include "StructUtils/UserDefinedStruct.h"
+#else
+	#include "Engine/UserDefinedStruct.h"
+#endif
 
 #define LOCTEXT_NAMESPACE "MDMetaDataEditor"
 

--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorCustomizationBase.cpp
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorCustomizationBase.cpp
@@ -7,7 +7,6 @@
 #include "DetailCategoryBuilder.h"
 #include "DetailLayoutBuilder.h"
 #include "DetailWidgetRow.h"
-#include "Engine/UserDefinedStruct.h"
 #include "HAL/PlatformApplicationMisc.h"
 #include "IDetailGroup.h"
 #include "K2Node_CustomEvent.h"
@@ -15,6 +14,7 @@
 #include "K2Node_FunctionResult.h"
 #include "K2Node_Tunnel.h"
 #include "Kismet2/BlueprintEditorUtils.h"
+#include "Misc/EngineVersionComparison.h"
 #include "ScopedTransaction.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SCheckBox.h"
@@ -23,6 +23,12 @@
 #include "Widgets/SMDMetaDataGameplayTagPicker.h"
 #include "Widgets/SMDMetaDataStringComboBox.h"
 #include "Widgets/Text/STextBlock.h"
+
+#if UE_VERSION_NEWER_THAN_OR_EQUAL(5,5,0)
+	#include "StructUtils/UserDefinedStruct.h"
+#else
+	#include "Engine/UserDefinedStruct.h"
+#endif
 
 FMDMetaDataEditorCustomizationBase::FMDMetaDataEditorCustomizationBase(const TWeakPtr<IBlueprintEditor>& BlueprintEditor, TWeakObjectPtr<UBlueprint>&& BlueprintPtr)
 	: BlueprintEditor(BlueprintEditor)

--- a/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorStructCustomization.cpp
+++ b/Source/MDMetaDataEditor/Private/Customizations/MDMetaDataEditorStructCustomization.cpp
@@ -5,8 +5,14 @@
 #include "Config/MDMetaDataEditorConfig.h"
 #include "Customizations/MDMetaDataEditorFieldView.h"
 #include "DetailLayoutBuilder.h"
-#include "Engine/UserDefinedStruct.h"
 #include "Kismet2/StructureEditorUtils.h"
+#include "Misc/EngineVersionComparison.h"
+
+#if UE_VERSION_NEWER_THAN_OR_EQUAL(5,5,0)
+	#include "StructUtils/UserDefinedStruct.h"
+#else
+	#include "Engine/UserDefinedStruct.h"
+#endif
 
 FMDMetaDataEditorStructCustomization::FMDMetaDataEditorStructCustomization(TWeakPtr<FMDUserStructMetaDataEditorView> InStructMetaDataView)
 	: FMDMetaDataEditorCustomizationBase(nullptr, nullptr)

--- a/Source/MDMetaDataEditor/Private/MDMetaDataEditorModule.cpp
+++ b/Source/MDMetaDataEditor/Private/MDMetaDataEditorModule.cpp
@@ -8,14 +8,20 @@
 #include "Customizations/MDMetaDataEditorPropertyTypeCustomization.h"
 #include "Customizations/MDMetaDataEditorStructChangeHandler.h"
 #include "Customizations/MDMetaDataEditorVariableCustomization.h"
-#include "Engine/UserDefinedStruct.h"
 #include "K2Node_CustomEvent.h"
 #include "K2Node_FunctionEntry.h"
 #include "K2Node_Tunnel.h"
+#include "Misc/EngineVersionComparison.h"
 #include "Modules/ModuleManager.h"
 #include "PropertyEditorModule.h"
 #include "Widgets/Docking/SDockTab.h"
 #include "Widgets/SMDUserStructMetaDataEditor.h"
+
+#if UE_VERSION_NEWER_THAN_OR_EQUAL(5,5,0)
+	#include "StructUtils/UserDefinedStruct.h"
+#else
+	#include "Engine/UserDefinedStruct.h"
+#endif
 
 void FMDMetaDataEditorModule::StartupModule()
 {

--- a/Source/MDMetaDataEditor/Private/Widgets/SMDUserStructMetaDataEditor.h
+++ b/Source/MDMetaDataEditor/Private/Widgets/SMDUserStructMetaDataEditor.h
@@ -2,10 +2,16 @@
 
 #pragma once
 
-#include "Engine/UserDefinedStruct.h"
 #include "Kismet2/StructureEditorUtils.h"
 #include "Misc/NotifyHook.h"
 #include "Widgets/SCompoundWidget.h"
+#include "Misc/EngineVersionComparison.h"
+
+#if UE_VERSION_NEWER_THAN_OR_EQUAL(5,5,0)
+	#include "StructUtils/UserDefinedStruct.h"
+#else
+	#include "Engine/UserDefinedStruct.h"
+#endif
 
 class FSpawnTabArgs;
 class IDetailsView;


### PR DESCRIPTION
Update includes for 5.8 removal of Engine/UserDefinedStruct.h. Since 5.5 that header has included the version in StructUtils, but they've cleaned things up and finally deleted the Engine version.